### PR TITLE
Fix translation endpoint embedder call

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -71,7 +71,6 @@ async function ensureEmbedder() {
 }
 
 async function embedMany(texts) {
-async function embedMany(texts) {
   const pipe = await ensureEmbedder();
   const out = await pipe(texts, { pooling: 'mean', normalize: true });
 
@@ -106,7 +105,6 @@ async function embedMany(texts) {
     res[i] = vec.subarray(i * dim, (i + 1) * dim);
   }
   return res;
-}
 }
 
 async function loadVocab() {


### PR DESCRIPTION
## Summary
- remove the accidental nested redefinition of `embedMany` so the server returns embeddings instead of `undefined`

## Testing
- not run (network access required to download model)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691299246fe8832d953f6da6ec15fb4b)