### PR TITLE
Fix Three.js import resolution with import map

### DIFF
--- a/server/public/app.js
+++ b/server/public/app.js
@@ -1,4 +1,4 @@
-import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
+import * as THREE from 'three';
 import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/controls/OrbitControls.js';
 
 const KIND_COLOR_VARS = {

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -8,6 +8,13 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22/>">
   <!-- compromise (POS tagger) from CDN -->
   <script src="https://cdn.jsdelivr.net/npm/compromise@14.13.0/builds/compromise.min.js"></script>
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js"
+      }
+    }
+  </script>
 </head>
 <body>
   <header>


### PR DESCRIPTION
## Summary
- add an import map that points the `three` specifier at the CDN three.js module
- update the app script to import `three` via the specifier so OrbitControls resolves correctly

## Testing
- npm start *(fails: model download requires network access in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69138a307fd0832d9721aa98e4c5f1d5)