### PR TITLE
Refine translation results display

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -263,8 +263,7 @@ app.post('/api/search', async (req, res) => {
       target = 'work',
       k = DEFAULT_K,
       contextTemplate = '{w}',
-      includeSeeds = true,
-      excludeInputs = true
+      includeSeeds = true
     } = req.body || {};
 
     if (!matrix) {
@@ -308,7 +307,7 @@ app.post('/api/search', async (req, res) => {
     const translated = normalized ? normalizeVec(transformed) : transformed;
 
     // knn among vocab using the translated target vector
-    const excludeSet = new Set(excludeInputs ? [...pairs.flat(), target] : []);
+    const excludeSet = new Set([...pairs.flat(), target]);
     const neighbors = topKSimilar(translated, k, excludeSet);
 
     // assemble points for PCA

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -49,7 +49,6 @@ write, writing</textarea>
           <small>Use <code>{w}</code> where the word goes. Example: “I saw {w} yesterday.”</small>
         </div>
         <div class="checkboxes">
-          <label><input id="excludeInputs" type="checkbox" checked /> Exclude input words from neighbors</label>
           <label><input id="includeSeeds" type="checkbox" checked /> Plot seed words</label>
         </div>
       </div>
@@ -87,7 +86,25 @@ write, writing</textarea>
   </section>
 
   <section class="results">
-    <h2>Top neighbors</h2>
+    <div class="summary-grid">
+      <div class="summary-card seed-card">
+        <h2>Seed pairs</h2>
+        <table id="seedPairsTable">
+          <thead><tr><th>From</th><th>To</th><th>Vector</th></tr></thead>
+          <tbody id="seedPairsBody"></tbody>
+        </table>
+      </div>
+      <div class="summary-card small-card">
+        <h2>Target word</h2>
+        <p id="targetWord">—</p>
+      </div>
+      <div class="summary-card small-card">
+        <h2>Translated target</h2>
+        <p id="translatedWord">—</p>
+      </div>
+    </div>
+
+    <h2 id="neighborsHeading">Translated target neighbors</h2>
     <table id="neighborsTable">
       <thead><tr><th>#</th><th>Word</th><th>Score (cosine)</th><th>POS</th></tr></thead>
       <tbody></tbody>

--- a/server/public/styles.css
+++ b/server/public/styles.css
@@ -335,6 +335,65 @@ section.results h2 {
   font-size: 1.5rem;
 }
 
+.summary-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 2fr) repeat(auto-fit, minmax(200px, 1fr));
+  align-items: stretch;
+  margin-bottom: 36px;
+}
+
+.summary-card {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 18px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  box-shadow: var(--shadow);
+}
+
+.summary-card h2 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.summary-card p {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.summary-card.small-card {
+  justify-content: space-between;
+  min-height: 100%;
+}
+
+#seedPairsTable {
+  background: rgba(15, 23, 42, 0.45);
+}
+
+#seedPairsTable th,
+#seedPairsTable td {
+  font-size: 0.92rem;
+}
+
+#seedPairsTable td:last-child {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: var(--muted);
+}
+
+#seedPairsTable td[colspan="3"] {
+  text-align: center;
+  color: var(--muted);
+}
+
+#seedPairsTable tbody tr:nth-child(even) {
+  background: rgba(148, 163, 184, 0.05);
+}
+
 table {
   width: 100%;
   border-collapse: collapse;
@@ -403,5 +462,9 @@ footer {
 
   #legend {
     gap: 12px;
+  }
+
+  .summary-grid {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- add a summary section that surfaces the seed pairs, their vectors, the target word, and the translated target alongside the neighbor list
- update the search workflow to keep the summary in sync with requests and always exclude seed/target words from neighbor retrieval
- refresh the results layout and styles to focus on the requested data points

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913a4b4fc64832da565cd09577b4f7c)