### PR TITLE
Display visualization and results side by side

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -73,25 +73,27 @@ write, writing</textarea>
     </div>
   </section>
 
-  <section class="viz">
-    <div id="chart"></div>
-    <div id="legend">
-      <div class="legend-item"><span class="legend-dot neighbor"></span> Neighbors</div>
-      <div class="legend-item"><span class="legend-dot target"></span> Target</div>
-      <div class="legend-item"><span class="legend-dot predicted"></span> Predicted</div>
-      <div class="legend-item"><span class="legend-dot seedFrom"></span> Seed from</div>
-      <div class="legend-item"><span class="legend-dot seedTo"></span> Seed to</div>
-      <div class="legend-item"><span class="legend-line seed"></span> Seed vectors</div>
-      <div class="legend-item"><span class="legend-line translation"></span> Target translation</div>
+  <section class="output">
+    <div class="viz-card">
+      <div id="chart"></div>
+      <div id="legend">
+        <div class="legend-item"><span class="legend-dot neighbor"></span> Neighbors</div>
+        <div class="legend-item"><span class="legend-dot target"></span> Target</div>
+        <div class="legend-item"><span class="legend-dot predicted"></span> Predicted</div>
+        <div class="legend-item"><span class="legend-dot seedFrom"></span> Seed from</div>
+        <div class="legend-item"><span class="legend-dot seedTo"></span> Seed to</div>
+        <div class="legend-item"><span class="legend-line seed"></span> Seed vectors</div>
+        <div class="legend-item"><span class="legend-line translation"></span> Target translation</div>
+      </div>
     </div>
-  </section>
 
-  <section class="results">
-    <h2>Top neighbors</h2>
-    <table id="neighborsTable">
-      <thead><tr><th>#</th><th>Word</th><th>Score (cosine)</th><th>POS</th></tr></thead>
-      <tbody></tbody>
-    </table>
+    <div class="results-card">
+      <h2>Top neighbors</h2>
+      <table id="neighborsTable">
+        <thead><tr><th>#</th><th>Word</th><th>Score (cosine)</th><th>POS</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
   </section>
 
   <footer>

--- a/public/styles.css
+++ b/public/styles.css
@@ -229,16 +229,28 @@ input[type="range"]::-moz-range-thumb {
   cursor: pointer;
 }
 
-section.viz {
+section.output {
+  display: grid;
+  gap: clamp(20px, 4vw, 36px);
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: start;
+  padding: 0 clamp(16px, 5vw, 72px) clamp(32px, 6vw, 64px);
+}
+
+.viz-card,
+.results-card {
   display: flex;
   flex-direction: column;
-  align-items: center;
   gap: 18px;
-  padding: 0 clamp(16px, 5vw, 72px);
+}
+
+.viz-card {
+  align-items: center;
 }
 
 #chart {
-  width: min(80vw, 640px);
+  width: 100%;
+  max-width: 640px;
   aspect-ratio: 1 / 1;
   position: relative;
   background: var(--surface);
@@ -326,11 +338,7 @@ section.viz {
 .legend-line.seed { background: var(--seedVector); }
 .legend-line.translation { background: linear-gradient(90deg, var(--target), var(--pred)); }
 
-section.results {
-  padding: clamp(32px, 6vw, 64px);
-}
-
-section.results h2 {
+.results-card h2 {
   margin: 0 0 16px;
   font-size: 1.5rem;
 }
@@ -383,8 +391,12 @@ footer {
     grid-template-columns: 1fr;
   }
 
+  section.output {
+    grid-template-columns: 1fr;
+  }
+
   #chart {
-    width: min(90vw, 560px);
+    max-width: min(100%, 560px);
   }
 }
 


### PR DESCRIPTION
## Summary
- place the visualization and neighbors table in a shared output section beneath the controls
- adjust styling so the chart and results align side by side on wide screens and stack responsively on narrow viewports

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914bb0d41d0832d82b22a9159389900)