### PR TITLE
Use WordNet POS metadata for vocabulary filtering

### DIFF
--- a/python_scripts.py
+++ b/python_scripts.py
@@ -3,7 +3,23 @@
 import nltk
 from nltk.corpus import wordnet as wn
 
+POS_MAP = {
+    "n": "Noun",
+    "v": "Verb",
+    "a": "Adjective",
+    "s": "Adjective",  # satellite adjectives → treat as adjectives
+    "r": "Adverb",
+}
+
+
 def build_lemma_vocab(output_file: str = "vocab.txt") -> None:
+    """Build a vocabulary file with lemmas and their WordNet POS tags.
+
+    Each line in the generated file has the format ``lemma\tPOS[,POS...]`` where
+    POS values are human-readable categories ("Noun", "Verb", ...). Lemmas that
+    appear under multiple parts of speech will list all of them.
+    """
+
     # Make sure WordNet is available (safe if already downloaded)
     try:
         wn.ensure_loaded()
@@ -11,24 +27,34 @@ def build_lemma_vocab(output_file: str = "vocab.txt") -> None:
         nltk.download("wordnet")
         wn.ensure_loaded()
 
-    lemmas = set()
+    lemma_pos: dict[str, set[str]] = {}
 
     # Iterate over all synsets and their lemmas
     for syn in wn.all_synsets():
-        for l in syn.lemmas():
-            name = l.name().lower()  # e.g., "dog", "ice_cream"
+        pos_label = POS_MAP.get(syn.pos())
+        if not pos_label:
+            continue  # Skip unexpected POS values
+
+        for lemma in syn.lemmas():
+            name = lemma.name().lower()  # e.g., "dog", "ice_cream"
 
             # Keep only purely alphabetic single-word lemmas
-            if name.isalpha():
-                lemmas.add(name)
+            if not name.isalpha():
+                continue
 
-    lemmas = sorted(lemmas)
+            bucket = lemma_pos.setdefault(name, set())
+            bucket.add(pos_label)
+
+    words = sorted(lemma_pos.keys())
 
     with open(output_file, "w", encoding="utf-8") as f:
-        for lemma in lemmas:
-            f.write(lemma + "\n")
+        for word in words:
+            pos_values = sorted(lemma_pos[word])
+            if not pos_values:
+                continue
+            f.write(f"{word}\t{','.join(pos_values)}\n")
 
-    print(f"Saved {len(lemmas)} lemmas to {output_file}")
+    print(f"Saved {len(words)} lemmas to {output_file}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update the WordNet vocabulary builder to emit lemmas alongside their POS labels
- load POS metadata on the server and include it in neighbor responses
- switch the client-side filtering to rely on the provided POS information instead of heuristic tagging

## Testing
- node --check index.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691630969e54832da5f30425a1ae8db2)